### PR TITLE
Feature add table components

### DIFF
--- a/src/app/components/tables/conjugation-table.test.tsx
+++ b/src/app/components/tables/conjugation-table.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import ConjugationTable from './conjugation-table';
+import '@testing-library/jest-dom';
+
+describe('ConjugationTable', () => {
+  const baseProps = {
+    title: 'Presente Simple',
+    subtitle: '(Affirmative)',
+    description: 'Uso del presente simple en afirmaciones.',
+    columns: ['Sujeto', 'Conjugación', 'Ejemplo'],
+    rows: [
+      { subject: 'I', conjugation: 'work', example: 'I work every day.' },
+      { subject: 'He', conjugation: 'works', example: 'He works on weekends.' },
+    ],
+  };
+
+  it('should render the title and subtitle', () => {
+    render(<ConjugationTable {...baseProps} />);
+    expect(screen.getByText('Presente Simple')).toBeInTheDocument();
+    expect(screen.getByText('(Affirmative)')).toBeInTheDocument();
+  });
+
+  it('should render the description if provided', () => {
+    render(<ConjugationTable {...baseProps} />);
+    expect(screen.getByText(baseProps.description)).toBeInTheDocument();
+  });
+
+  it('should not render the description if not provided', () => {
+    const propsWithoutDescription = { ...baseProps, description: undefined };
+    render(<ConjugationTable {...propsWithoutDescription} />);
+    expect(screen.queryByText('Uso del presente simple en afirmaciones.')).not.toBeInTheDocument();
+  });
+
+  it('should render the correct column headers', () => {
+    render(<ConjugationTable {...baseProps} />);
+    baseProps.columns.forEach((col) => {
+      expect(screen.getByRole('columnheader', { name: col })).toBeInTheDocument();
+    });
+  });
+
+  it('should render all table rows with correct data', () => {
+    render(<ConjugationTable {...baseProps} />);
+    baseProps.rows.forEach((row) => {
+      expect(screen.getByText(row.subject)).toBeInTheDocument();
+      expect(screen.getByText(row.conjugation)).toBeInTheDocument();
+      expect(screen.getByText(row.example)).toBeInTheDocument();
+    });
+  });
+
+  it('should render an empty table body if there are no rows', () => {
+    render(<ConjugationTable {...baseProps} rows={[]} />);
+    const rows = screen.queryAllByRole('row');
+    // 1 header row + 0 body rows
+    expect(rows.length).toBe(1);
+  });
+});

--- a/src/app/components/tables/conjugation-table.tsx
+++ b/src/app/components/tables/conjugation-table.tsx
@@ -1,0 +1,48 @@
+interface TableRow {
+  subject: string
+  conjugation: string
+  example: string
+}
+
+export interface ConjugationTableProps {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  columns: string[];
+  rows: TableRow[];
+}
+
+export default function ConjugationTable({ title, subtitle, description, columns, rows }: ConjugationTableProps) {
+  return (
+    <div className="mb-8">
+      <h3 className="text-xl font-subtitle text-white mb-2">
+        {title} {subtitle && <span className="text-gray-300">{subtitle}</span>}
+      </h3>
+
+      {description && <p className="text-gray-300 mb-4 font-text">{description}</p>}
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr>
+              {columns.map((column, index) => (
+                <th key={index} className="border border-gray-600 bg-gray-800 text-left p-3 text-white font-subtitle">
+                  {column}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="font-table">
+            {rows.map((row, index) => (
+              <tr key={index} className={index % 2 === 0 ? "bg-gray-900" : "bg-gray-800"}>
+                <td className="border border-gray-600 p-3 text-white">{row.subject}</td>
+                <td className="border border-gray-600 p-3 text-white">{row.conjugation}</td>
+                <td className="border border-gray-600 p-3 text-white">{row.example}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/tables/section-tables.test.tsx
+++ b/src/app/components/tables/section-tables.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import SectionTables from './section-tables';
+import '@testing-library/jest-dom';
+
+jest.mock('./conjugation-table', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="tabla-mock">{title}</div>,
+}));
+
+describe('SectionTables', () => {
+  const mockTables = [
+    {
+      id: '1',
+      title: 'Simple Present',
+      subtitle: '(Affirmative)',
+      description: 'Use of the simple present.',
+      columns: ['Subject', 'Verb', 'Example'],
+      rows: [
+        { subject: 'I', conjugation: 'work', example: 'I work.' },
+        { subject: 'He', conjugation: 'works', example: 'He works.' },
+      ],
+    },
+    {
+      id: '2',
+      title: 'Simple Past',
+      columns: ['Subject', 'Verb', 'Example'],
+      rows: [
+        { subject: 'I', conjugation: 'worked', example: 'I worked.' },
+        { subject: 'She', conjugation: 'worked', example: 'She worked.' },
+      ],
+    },
+  ];
+
+  it('should render the section title', () => {
+    render(<SectionTables tables={mockTables} />);
+    expect(screen.getByText('Tablas de Conjugación')).toBeInTheDocument();
+  });
+
+  it('should render one TablaConjugacion per item in tablas', () => {
+    render(<SectionTables tables={mockTables} />);
+    const tablaElements = screen.getAllByTestId('tabla-mock');
+    expect(tablaElements).toHaveLength(mockTables.length);
+  });
+
+  it('should render each table title inside TablaConjugacion', () => {
+    render(<SectionTables tables={mockTables} />);
+    mockTables.forEach((tabla) => {
+      expect(screen.getByText(tabla.title)).toBeInTheDocument();
+    });
+  });
+
+  it('should render nothing if no tables are provided', () => {
+    render(<SectionTables tables={[]} />);
+    expect(screen.queryByTestId('tabla-mock')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/components/tables/section-tables.tsx
+++ b/src/app/components/tables/section-tables.tsx
@@ -1,0 +1,39 @@
+import TablaConjugacion from "./conjugation-table"
+
+interface ConjugationTableData {
+  id: string
+  title: string
+  subtitle?: string
+  description?: string
+  columns: string[]
+  rows: {
+    subject: string
+    conjugation: string
+    example: string
+  }[]
+}
+
+interface SectionTablesProps {
+  tables: ConjugationTableData[]
+}
+
+export default function SectionTables({ tables }: SectionTablesProps) {
+  return (
+    <div className="bg-gray-900 p-6 rounded-lg">
+      <h2 className="text-2xl font-title text-white mb-6">Tablas de Conjugación</h2>
+
+      <div className="space-y-8">
+        {tables.map((table) => (
+          <TablaConjugacion
+            key={table.id}
+            title={table.title}
+            subtitle={table.subtitle}
+            description={table.description}
+            columns={table.columns}
+            rows={table.rows}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Se crearon dos componentes de tabla:
- Uno de ellos llamado llamado **ConjugationTable** recibe información para mostrar una tabla de conjugaciones. Utiliza los datos proporcionados en props como título, subtítulo, descripción, nombres de columnas y las filas con sujeto, conjugación y ejemplo para renderizar una tabla HTML estilizada. También se hicieron sus tests. 
- El otro de ellos llamado **SectionTables**, recibe un array de datos de tablas de conjugación. Itera sobre este array y renderiza el componente **TablaConjugacion** (importado como TablaConjugacion) para cada conjunto de datos, pasando las propiedades necesarias para mostrar cada tabla individualmente. También se hicieron sus tests. 